### PR TITLE
Updated go-media for nil frames

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,11 @@
 module github.com/mutablelogic/go-media
 
-go 1.20
+go 1.22
+
+toolchain go1.22.3
 
 require (
-	github.com/alecthomas/kong v0.9.0
 	github.com/djthorpe/go-errors v1.0.3
-	github.com/djthorpe/go-tablewriter v0.0.8
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
 	github.com/llgcode/draw2d v0.0.0-20240627062922-0ed1ff131195
 	github.com/mutablelogic/go-client v1.0.8
@@ -16,11 +16,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/rivo/uniseg v0.4.7 // indirect
 	golang.org/x/image v0.18.0 // indirect
-	golang.org/x/sys v0.21.0 // indirect
-	golang.org/x/term v0.21.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/pkg/ffmpeg/decoder.go
+++ b/pkg/ffmpeg/decoder.go
@@ -156,8 +156,11 @@ func (d *Decoder) decode(packet *ff.AVPacket, fn DecoderFrameFn) error {
 		}
 
 		// Copy across the timebase and pts
-		(*ff.AVFrame)(dest).SetPts(d.frame.Pts())
-		(*ff.AVFrame)(dest).SetTimeBase(d.timeBase)
+		// TODO if dest != nil {
+		//	fmt.Println("pts=", d.frame.Pts())
+		//		(*ff.AVFrame)(dest).SetPts(d.frame.Pts())
+		//		(*ff.AVFrame)(dest).SetTimeBase(d.timeBase)
+		//}
 
 		// Pass back to the caller
 		if err := fn(d.stream, dest); errors.Is(err, io.EOF) {


### PR DESCRIPTION
* Removed some decoder code which causes a crash
* The timestamp no longer moves from a resampled frame to destination, which should be fixed