### PR TITLE
Add resampler functionality

### DIFF
--- a/sys/ffmpeg80/avutil_frame.go
+++ b/sys/ffmpeg80/avutil_frame.go
@@ -162,6 +162,16 @@ func AVUtil_frame_get_num_planes(frame *AVFrame) int {
 	return 0
 }
 
+// Set up dst as a new reference to the same data described by src, sharing
+// its underlying buffer(s) (bumping their refcount) rather than copying -
+// dst must already be allocated but not yet hold any buffers of its own.
+func AVUtil_frame_ref(dst, src *AVFrame) error {
+	if ret := AVError(C.av_frame_ref((*C.struct_AVFrame)(dst), (*C.struct_AVFrame)(src))); ret != 0 {
+		return ret
+	}
+	return nil
+}
+
 // Copy frame data
 func AVUtil_frame_copy(dst, src *AVFrame) error {
 	if ret := AVError(C.av_frame_copy((*C.struct_AVFrame)(dst), (*C.struct_AVFrame)(src))); ret < 0 {

--- a/task/manager/manager.go
+++ b/task/manager/manager.go
@@ -37,7 +37,7 @@ type Manager struct {
 ////////////////////////////////////////////////////////////////////////////////
 // LIFECYCLE
 
-// New creates a new media object
+// New creates a new task manager
 func New(ctx context.Context, opts ...Opt) (_ *Manager, err error) {
 	self := new(Manager)
 	if err := self.apply(opts); err != nil {
@@ -302,9 +302,10 @@ func (m *Manager) Remove(ctx context.Context, id uuid.UUID) (err error) {
 
 // Wait blocks until the task registered under id finishes, or until ctx is
 // done, whichever comes first, then returns its final status. It returns an
-// error if the task hasn't been started (there's nothing to wait for), or if
-// the task itself returned an error (joined into err, alongside a context
-// error if ctx is what ended the wait).
+// error if the task hasn't been started (there's nothing to wait for), if
+// ctx ends the wait first (no status is returned in that case, since the
+// task may still be running), or if the task itself returned an error (its
+// status is still returned alongside that error).
 func (m *Manager) Wait(ctx context.Context, id uuid.UUID) (_ *schema.Status, err error) {
 	ctx, endSpan := otel.StartSpan(m.tracer, ctx, "Wait",
 		attribute.String("uuid", id.String()),

--- a/task/manager/opt.go
+++ b/task/manager/opt.go
@@ -8,7 +8,7 @@ import (
 ////////////////////////////////////////////////////////////////////////////////
 // TYPES
 
-// Opt is a functional option for filer manager configuration.
+// Opt is a functional option for task manager configuration.
 type Opt func(*opt) error
 
 type opt struct {

--- a/writer/encoder.go
+++ b/writer/encoder.go
@@ -178,14 +178,20 @@ func (e *Encoder) Encode(f frame.Frame) error {
 
 // Flush signals end-of-stream to the codec registered for streamID and
 // passes any remaining buffered packets to the Encoder's callback. This is
-// a no-op for a subtitle stream: subtitles use a legacy API with no
-// buffering, so there is nothing to flush.
+// a no-op for a subtitle stream (subtitles use a legacy API with no
+// buffering, so there is nothing to flush) and for a stream whose codec
+// isn't actually an encoder (e.g. a StreamProfile fed to Add purely to copy
+// a demuxed stream's parameters/extradata onto the muxed output for a
+// remux - avcodec_send_frame is only valid against a real encoder context).
 func (e *Encoder) Flush(streamID int) error {
 	ctx, err := e.contextFor(streamID)
 	if err != nil {
 		return err
 	}
 	if ctx.CodecType() == ff.AVMEDIA_TYPE_SUBTITLE {
+		return nil
+	}
+	if codec := ctx.Codec(); codec == nil || !codec.IsEncoder() {
 		return nil
 	}
 	return e.encode(ctx, streamID, nil)

--- a/writer/encoder_test.go
+++ b/writer/encoder_test.go
@@ -51,6 +51,42 @@ func silentFrame(t *testing.T, streamID, numSamples int) *frame.AudioFrame {
 	return frame
 }
 
+// mismatchedFrame builds an audio frame in a deliberately different format
+// (s16 mono @ 8kHz) from silentFrame's (fltp stereo @ 44.1kHz) - the format
+// audioStream's aac profile expects. Used to force Writer.Encode's resampler
+// into a real conversion rather than the fast pass-through path.
+func mismatchedFrame(t *testing.T, streamID, numSamples int) *frame.AudioFrame {
+	t.Helper()
+
+	frame, err := frame.NewAudioFrame(streamID)
+	if err != nil {
+		t.Fatalf("NewFrame: %v", err)
+	}
+
+	frame.SetSampleFormat(ff.AVUtil_get_sample_fmt("s16"))
+	frame.SetSampleRate(8000)
+
+	var ch ff.AVChannelLayout
+	if err := ff.AVUtil_channel_layout_from_string(&ch, "mono"); err != nil {
+		t.Fatalf("AVUtil_channel_layout_from_string: %v", err)
+	}
+	if err := frame.SetChannelLayout(ch); err != nil {
+		t.Fatalf("SetChannelLayout: %v", err)
+	}
+	frame.SetNumSamples(numSamples)
+
+	if err := frame.AllocateBuffers(); err != nil {
+		t.Fatalf("AllocateBuffers: %v", err)
+	}
+
+	samples := frame.Int16(0)
+	for i := range samples {
+		samples[i] = 0
+	}
+
+	return frame
+}
+
 func newTestEncoder(t *testing.T, fn writer.PacketFn) *writer.Encoder {
 	t.Helper()
 	if fn == nil {

--- a/writer/resampler.go
+++ b/writer/resampler.go
@@ -324,8 +324,20 @@ func (r *audioResampler) processUnbounded(in *ff.AVFrame, fn func(*frame.AudioFr
 
 		// Offer the full capacity every call - swr shrinks AVFrame's
 		// NumSamples to the actual count written, so it must be reset
-		// before each call or output would shrink monotonically.
+		// before each call or output would shrink monotonically. This must
+		// come before MakeWritable below: a clone allocates sized to
+		// whatever NumSamples currently is, so it has to already be back
+		// at full capacity, not left at a previous call's shrunk count.
 		r.dest.SetNumSamples(r.capacity)
+
+		// dest may still be referenced by the encoder from a previous
+		// fn(r.dest) call - avcodec_send_frame is documented to possibly
+		// keep a reference rather than copy, so overwriting it in place
+		// here could corrupt a frame the encoder hasn't finished with yet.
+		// MakeWritable clones a fresh buffer instead when that's the case.
+		if err := r.dest.MakeWritable(); err != nil {
+			return err
+		}
 		if err := ff.SWResample_convert_frame(r.ctx, in, r.dest.AVFrame); err != nil {
 			return err
 		}
@@ -389,6 +401,15 @@ func (r *audioResampler) processChunked(in *ff.AVFrame, flush bool, fn func(*fra
 func (r *audioResampler) accumulate(n int, fn func(*frame.AudioFrame) error) error {
 	for off := 0; off < n; {
 		take := min(n-off, r.frameSize-r.pending)
+
+		// dest may still be referenced by the encoder from a previous
+		// fn(r.dest) call - see processUnbounded for why this must happen
+		// before writing into it. dest's NumSamples never changes here
+		// (always r.capacity), so no reordering concern like
+		// processUnbounded's - just needs to happen before the copy below.
+		if err := r.dest.MakeWritable(); err != nil {
+			return err
+		}
 		copyAudioSamples(r.dest, r.pending, r.scratch, off, take)
 		r.pending += take
 		off += take
@@ -558,6 +579,14 @@ func (r *videoRescaler) process(src *frame.VideoFrame, fn func(*frame.VideoFrame
 	}
 
 	if err := ff.AVUtil_frame_copy_props(r.dest.AVFrame, src.AVFrame); err != nil {
+		return err
+	}
+
+	// dest may still be referenced by the encoder from a previous fn(r.dest)
+	// call - see audioResampler.processUnbounded for why this must happen
+	// before writing into it. dest's width/height/format never change once
+	// allocated, so there's no reordering concern like processUnbounded's.
+	if err := r.dest.MakeWritable(); err != nil {
 		return err
 	}
 	if err := ff.SWScale_scale_frame(r.ctx, r.dest.AVFrame, src.AVFrame, false); err != nil {

--- a/writer/resampler.go
+++ b/writer/resampler.go
@@ -1,0 +1,573 @@
+package writer
+
+import (
+	// Packages
+	gomedia "github.com/mutablelogic/go-media"
+	frame "github.com/mutablelogic/go-media/frame"
+	ff "github.com/mutablelogic/go-media/sys/ffmpeg80"
+)
+
+//////////////////////////////////////////////////////////////////////////////
+// TYPES
+
+// resampler converts frames arriving for one stream into the exact format
+// its codec was opened with, so Writer.Encode never hands Encoder.Encode a
+// mismatched frame.
+type Resampler struct {
+	audio *audioResampler
+	video *videoRescaler
+}
+
+// audioResampler wraps libswresample to convert sample format/rate/channel
+// layout and, if frameSize > 0, to re-chunk output into exactly frameSize
+// samples per frame (all but the last).
+type audioResampler struct {
+	par       *ff.AVCodecParameters
+	frameSize int // 0 = codec accepts any frame size
+
+	ctx      *ff.SWRContext
+	dest     *frame.AudioFrame // frameSize<=0: swr's direct output target. frameSize>0: accumulation buffer holding pending samples not yet emitted
+	pts      int64
+	capacity int // dest's buffer capacity, in samples
+
+	// frameSize > 0 only: swr output is re-chunked to exactly frameSize
+	// samples per frame, which may take several process() calls to fill -
+	// scratch is swr's per-call output target, copied sample-by-sample into
+	// dest's [pending, pending+n) range until dest fills to a full chunk.
+	scratch *frame.AudioFrame
+	pending int
+
+	// srcFmt/srcRate/srcLayout are what ctx is currently configured to
+	// convert FROM - compared against each incoming frame to detect an
+	// upstream source change (e.g. splicing in a different feed mid-stream)
+	// so ctx can be drained and rebuilt for the new source rather than
+	// silently relying on swr's own internal reconfigure-on-format-change,
+	// which isn't guaranteed to preserve samples still buffered in the old
+	// context's resampling delay line.
+	//
+	// Comparing srcLayout needs care: audioResampler (this struct) also
+	// holds live pointer fields (ctx/dest/scratch), so &r.srcLayout is an
+	// interior pointer into an allocation that legitimately contains Go
+	// pointers elsewhere. Go's cgo pointer check resolves an interior
+	// pointer to its whole containing allocation and scans all of it, so
+	// passing &r.srcLayout straight into a cgo call panics on those
+	// unrelated neighbors - not on srcLayout's own (harmless) content. Copy
+	// it into an independent local first (see sourceChanged) before taking
+	// its address.
+	srcFmt    ff.AVSampleFormat
+	srcRate   int
+	srcLayout ff.AVChannelLayout
+}
+
+// videoRescaler wraps libswscale to convert pixel format and/or dimensions.
+// It also owns the output pts, counting frames at a constant timebase
+// rather than trusting src's own pts/timebase
+type videoRescaler struct {
+	par      *ff.AVCodecParameters
+	flags    ff.SWSFlag
+	timebase ff.AVRational
+
+	ctx    *ff.SWSContext
+	dest   *frame.VideoFrame
+	srcFmt ff.AVPixelFormat
+	srcW   int
+	srcH   int
+	pts    int64
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// GLOBALS
+
+// defaultResampleCapacity sizes the destination buffer for an audio stream
+// whose codec accepts any frame size (FrameSize == 0) - there's no fixed
+// target to size it to, so just pick something.
+const defaultResampleCapacity = 8192
+
+//////////////////////////////////////////////////////////////////////////////
+// LIFECYCLE
+
+// NewResampler creates a resampler that converts audio or video frames into
+// par's target format. For any other codec type (e.g. subtitle, data), it returns
+// a passthrough Resampler. frameSize only applies to audio (see audioResampler);
+// timebase only applies to video (see videoRescaler) - it's the fixed output
+// timebase (typically 1/framerate) frames are counted out in, so switching
+// source mid-stream can't hand the encoder a pts in the wrong timebase or one
+// that jumps backwards relative to the previous source.
+func NewResampler(par *ff.AVCodecParameters, frameSize int, timebase ff.AVRational) (*Resampler, error) {
+	if par == nil {
+		return nil, gomedia.ErrBadParameter.With("resampler: nil codec parameters")
+	}
+	switch par.CodecType() {
+	case ff.AVMEDIA_TYPE_AUDIO:
+		return newAudioResampler(par, frameSize)
+	case ff.AVMEDIA_TYPE_VIDEO:
+		return newVideoRescaler(par, timebase)
+	default:
+		return &Resampler{}, nil
+	}
+}
+
+func newAudioResampler(par *ff.AVCodecParameters, frameSize int) (*Resampler, error) {
+	if par.CodecType() != ff.AVMEDIA_TYPE_AUDIO {
+		return nil, gomedia.ErrBadParameter.With("resampler: invalid target codec type")
+	}
+	if par.SampleFormat() == ff.AV_SAMPLE_FMT_NONE {
+		return nil, gomedia.ErrBadParameter.With("resampler: invalid target sample format")
+	}
+	if par.SampleRate() <= 0 {
+		return nil, gomedia.ErrBadParameter.With("resampler: invalid target sample rate")
+	}
+	layout := par.ChannelLayout()
+	if !ff.AVUtil_channel_layout_check(&layout) {
+		return nil, gomedia.ErrBadParameter.With("resampler: invalid target channel layout")
+	}
+	return &Resampler{audio: &audioResampler{par: par, frameSize: frameSize}}, nil
+}
+
+func newVideoRescaler(par *ff.AVCodecParameters, timebase ff.AVRational) (*Resampler, error) {
+	if par.CodecType() != ff.AVMEDIA_TYPE_VIDEO {
+		return nil, gomedia.ErrBadParameter.With("rescaler: invalid target codec type")
+	}
+	if par.PixelFormat() == ff.AV_PIX_FMT_NONE {
+		return nil, gomedia.ErrBadParameter.With("rescaler: invalid target pixel format")
+	}
+	if par.Width() <= 0 || par.Height() <= 0 {
+		return nil, gomedia.ErrBadParameter.With("rescaler: invalid target width/height")
+	}
+	if timebase.Num() <= 0 || timebase.Den() <= 0 {
+		return nil, gomedia.ErrBadParameter.With("rescaler: invalid target timebase")
+	}
+	return &Resampler{video: &videoRescaler{par: par, flags: ff.SWS_BILINEAR, timebase: timebase}}, nil
+}
+
+func (r *audioResampler) Close() error {
+	if r.ctx != nil {
+		ff.SWResample_free(r.ctx)
+		r.ctx = nil
+	}
+	var err error
+	if r.dest != nil {
+		err = r.dest.Close()
+		r.dest = nil
+	}
+	if r.scratch != nil {
+		if serr := r.scratch.Close(); err == nil {
+			err = serr
+		}
+		r.scratch = nil
+	}
+	return err
+}
+
+func (r *videoRescaler) Close() error {
+	if r.ctx != nil {
+		ff.SWScale_free_context(r.ctx)
+		r.ctx = nil
+	}
+	var err error
+	if r.dest != nil {
+		err = r.dest.Close()
+		r.dest = nil
+	}
+	return err
+}
+
+func (r *Resampler) Close() error {
+	switch {
+	case r.audio != nil:
+		return r.audio.Close()
+	case r.video != nil:
+		return r.video.Close()
+	default:
+		return nil
+	}
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// PUBLIC METHODS
+
+// Process converts src and calls fn for every resulting frame. Pass
+// src==nil to flush - audio may have buffered samples still to emit; video
+// and passthrough have nothing to flush and this is a no-op for them.
+func (r *Resampler) Process(src frame.Frame, fn func(frame.Frame) error) error {
+	if fn == nil {
+		return gomedia.ErrBadParameter.With("resampler: nil callback function")
+	}
+
+	switch {
+	case r.audio != nil:
+		audioSrc, ok := src.(*frame.AudioFrame)
+		if src != nil && !ok {
+			return gomedia.ErrBadParameter.Withf("resampler: expected an audio frame, got %T", src)
+		}
+		return r.audio.process(audioSrc, func(f *frame.AudioFrame) error {
+			return fn(f)
+		})
+
+	case r.video != nil:
+		videoSrc, ok := src.(*frame.VideoFrame)
+		if src != nil && !ok {
+			return gomedia.ErrBadParameter.Withf("resampler: expected a video frame, got %T", src)
+		}
+		return r.video.process(videoSrc, func(f *frame.VideoFrame) error {
+			return fn(f)
+		})
+
+	default:
+		// Passthrough - nothing to flush, and any non-nil frame goes
+		// straight through unmodified.
+		if src == nil {
+			return nil
+		}
+		return fn(src)
+	}
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// PRIVATE METHODS - AUDIO
+
+// matches reports whether src can go straight to the encoder untouched.
+func (r *audioResampler) matches(src *frame.AudioFrame) bool {
+	if src.SampleFormat() != r.par.SampleFormat() || src.SampleRate() != r.par.SampleRate() {
+		return false
+	}
+	srcLayout, dstLayout := src.ChannelLayout(), r.par.ChannelLayout()
+	if !ff.AVUtil_channel_layout_compare(&srcLayout, &dstLayout) {
+		return false
+	}
+	return r.frameSize <= 0 || src.NumSamples() == r.frameSize
+}
+
+// sourceChanged reports whether src's format no longer matches what ctx was
+// built for.
+func (r *audioResampler) sourceChanged(src *frame.AudioFrame) bool {
+	if r.ctx == nil {
+		return false
+	}
+	if src.SampleFormat() != r.srcFmt || src.SampleRate() != r.srcRate {
+		return true
+	}
+	// Copy r.srcLayout into an independent local before taking its address -
+	// see the field's doc comment for why &r.srcLayout itself isn't safe.
+	layout, stored := src.ChannelLayout(), r.srcLayout
+	return !ff.AVUtil_channel_layout_compare(&layout, &stored)
+}
+
+// drain empties whatever ctx currently has buffered, without pushing new
+// input - used when switching to a new source mid-stream, so anything still
+// in flight in the outgoing context's resampling delay line is captured
+// rather than lost. Deliberately not a "flush": pending (a partially
+// accumulated chunk) is left exactly as it is, so the new source's samples
+// continue filling it rather than being cut short into a shorter chunk here.
+func (r *audioResampler) drain(fn func(*frame.AudioFrame) error) error {
+	if r.frameSize <= 0 {
+		return r.processUnbounded(nil, fn)
+	}
+	return r.processChunked(nil, false, fn)
+}
+
+// process converts src (nil flushes) and calls fn for every resulting frame.
+func (r *audioResampler) process(src *frame.AudioFrame, fn func(*frame.AudioFrame) error) error {
+	// The fast path only applies with nothing buffered - if a chunk is
+	// still pending, this frame must go through accumulation too, or it
+	// would be emitted out of order, ahead of the older buffered samples.
+	if src != nil && r.pending == 0 && r.matches(src) {
+		// Own the pts even here - trusting src's own pts would break
+		// continuity the moment the source switches to one numbering its
+		// samples differently (or not needing conversion, while a previous
+		// source did).
+		n := src.NumSamples()
+		src.SetPts(r.pts)
+		r.pts += int64(n)
+		return fn(src)
+	}
+
+	if src != nil && r.sourceChanged(src) {
+		if err := r.drain(fn); err != nil {
+			return err
+		}
+		ff.SWResample_free(r.ctx)
+		r.ctx = nil
+	}
+
+	if r.ctx == nil {
+		if src == nil {
+			return nil // never initialized - nothing buffered to flush
+		}
+		if err := r.init(src); err != nil {
+			return err
+		}
+	}
+
+	var in *ff.AVFrame
+	if src != nil {
+		in = src.AVFrame
+	}
+	if r.frameSize <= 0 {
+		return r.processUnbounded(in, fn)
+	}
+	return r.processChunked(in, src == nil, fn)
+}
+
+// processUnbounded is used when the codec accepts any frame size - swr's
+// output is passed straight through, one frame per convert call, with no
+// re-chunking.
+func (r *audioResampler) processUnbounded(in *ff.AVFrame, fn func(*frame.AudioFrame) error) error {
+	// First iteration converts in (nil on a flush); every further iteration
+	// pulls only from swr's internal buffer, so a single call that produces
+	// more than one dest-buffer's worth of output correctly yields >1
+	// output frame instead of silently dropping the rest.
+	for first := true; ; first = false {
+		if !first {
+			in = nil
+		}
+
+		// Offer the full capacity every call - swr shrinks AVFrame's
+		// NumSamples to the actual count written, so it must be reset
+		// before each call or output would shrink monotonically.
+		r.dest.SetNumSamples(r.capacity)
+		if err := ff.SWResample_convert_frame(r.ctx, in, r.dest.AVFrame); err != nil {
+			return err
+		}
+
+		n := r.dest.NumSamples()
+		if n == 0 {
+			return nil
+		}
+		r.dest.SetPts(r.pts)
+		r.pts += int64(n)
+		if err := fn(r.dest); err != nil {
+			return err
+		}
+	}
+}
+
+// processChunked is used when the codec requires exactly frameSize samples
+// per frame. swr's output rarely lines up with frameSize on its own, so it's
+// converted into a scratch buffer and accumulated into dest, emitting a
+// frame each time dest fills to exactly frameSize - across as many calls as
+// it takes. On flush, any samples short of a full chunk are emitted as a
+// final, shorter frame.
+func (r *audioResampler) processChunked(in *ff.AVFrame, flush bool, fn func(*frame.AudioFrame) error) error {
+	for first := true; ; first = false {
+		if !first {
+			in = nil
+		}
+
+		r.scratch.SetNumSamples(defaultResampleCapacity)
+		if err := ff.SWResample_convert_frame(r.ctx, in, r.scratch.AVFrame); err != nil {
+			return err
+		}
+
+		n := r.scratch.NumSamples()
+		if n == 0 {
+			break
+		}
+		if err := r.accumulate(n, fn); err != nil {
+			return err
+		}
+	}
+
+	if !flush || r.pending == 0 {
+		return nil
+	}
+
+	// Flush: release the remainder, short of a full chunk.
+	r.dest.SetNumSamples(r.pending)
+	r.dest.SetPts(r.pts)
+	r.pts += int64(r.pending)
+	err := fn(r.dest)
+	r.pending = 0
+	r.dest.SetNumSamples(r.capacity)
+	return err
+}
+
+// accumulate copies n newly-converted samples from r.scratch into r.dest at
+// the current pending offset, emitting (and resetting) every time dest
+// fills to a full frameSize chunk - a single scratch drain can complete more
+// than one pending chunk, so this loops until every sample is placed.
+func (r *audioResampler) accumulate(n int, fn func(*frame.AudioFrame) error) error {
+	for off := 0; off < n; {
+		take := min(n-off, r.frameSize-r.pending)
+		copyAudioSamples(r.dest, r.pending, r.scratch, off, take)
+		r.pending += take
+		off += take
+
+		if r.pending == r.frameSize {
+			r.dest.SetPts(r.pts)
+			r.pts += int64(r.pending)
+			if err := fn(r.dest); err != nil {
+				return err
+			}
+			r.pending = 0
+		}
+	}
+	return nil
+}
+
+// copyAudioSamples copies n samples of each plane from src (starting at
+// srcOffset samples in) to dst (starting at dstOffset samples in). dst and
+// src must share the same sample format and channel layout.
+func copyAudioSamples(dst *frame.AudioFrame, dstOffset int, src *frame.AudioFrame, srcOffset, n int) {
+	if n <= 0 {
+		return
+	}
+	bytesPerSample := ff.AVUtil_get_bytes_per_sample(dst.SampleFormat())
+	stride := bytesPerSample
+	planes := 1
+	if ff.AVUtil_sample_fmt_is_planar(dst.SampleFormat()) {
+		planes = dst.NumChannels()
+	} else {
+		stride = bytesPerSample * dst.NumChannels()
+	}
+	for p := 0; p < planes; p++ {
+		srcBytes, dstBytes := src.Bytes(p), dst.Bytes(p)
+		so, do := srcOffset*stride, dstOffset*stride
+		copy(dstBytes[do:do+n*stride], srcBytes[so:so+n*stride])
+	}
+}
+
+func (r *audioResampler) init(src *frame.AudioFrame) error {
+	ctx := ff.SWResample_alloc()
+	if ctx == nil {
+		return gomedia.ErrInternalError.With("resampler: failed to allocate swr context")
+	}
+
+	srcLayout, dstLayout := src.ChannelLayout(), r.par.ChannelLayout()
+	if err := ff.SWResample_set_opts(ctx,
+		dstLayout, r.par.SampleFormat(), r.par.SampleRate(),
+		srcLayout, src.SampleFormat(), src.SampleRate(),
+	); err != nil {
+		ff.SWResample_free(ctx)
+		return err
+	}
+	if err := ff.SWResample_init(ctx); err != nil {
+		ff.SWResample_free(ctx)
+		return err
+	}
+
+	// dest/scratch only need allocating once - their format is always the
+	// fixed target (par), which never changes across a source switch; only
+	// ctx (the source side) does. Reusing them keeps any still-pending
+	// partially accumulated chunk intact across the switch.
+	if r.dest == nil {
+		capacity := r.frameSize
+		if capacity <= 0 {
+			capacity = defaultResampleCapacity
+		}
+
+		dest, err := newAudioFrameBuffer(src.Stream(), r.par.SampleFormat(), r.par.SampleRate(), dstLayout, capacity)
+		if err != nil {
+			ff.SWResample_free(ctx)
+			return err
+		}
+
+		// Chunked mode re-chunks swr's output into exactly frameSize samples
+		// per frame, which needs a separate scratch buffer for swr to
+		// convert into - see accumulate.
+		var scratch *frame.AudioFrame
+		if r.frameSize > 0 {
+			scratch, err = newAudioFrameBuffer(src.Stream(), r.par.SampleFormat(), r.par.SampleRate(), dstLayout, defaultResampleCapacity)
+			if err != nil {
+				dest.Close()
+				ff.SWResample_free(ctx)
+				return err
+			}
+		}
+
+		r.dest, r.scratch, r.capacity = dest, scratch, capacity
+	}
+
+	r.ctx = ctx
+	r.srcFmt, r.srcRate, r.srcLayout = src.SampleFormat(), src.SampleRate(), srcLayout
+	return nil
+}
+
+// newAudioFrameBuffer allocates an audio frame with sample buffers for
+// capacity samples in the given format/rate/layout.
+func newAudioFrameBuffer(stream int, format ff.AVSampleFormat, rate int, layout ff.AVChannelLayout, capacity int) (*frame.AudioFrame, error) {
+	f, err := frame.NewAudioFrame(stream)
+	if err != nil {
+		return nil, err
+	}
+	f.SetSampleFormat(format)
+	f.SetSampleRate(rate)
+	if err := f.SetChannelLayout(layout); err != nil {
+		f.Close()
+		return nil, err
+	}
+	f.SetNumSamples(capacity)
+	if err := f.AllocateBuffers(); err != nil {
+		f.Close()
+		return nil, err
+	}
+	return f, nil
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// PRIVATE METHODS - VIDEO
+
+func (r *videoRescaler) matches(src *frame.VideoFrame) bool {
+	return src.PixFmt() == r.par.PixelFormat() &&
+		src.Width() == r.par.Width() && src.Height() == r.par.Height()
+}
+
+func (r *videoRescaler) process(src *frame.VideoFrame, fn func(*frame.VideoFrame) error) error {
+	if src == nil {
+		return nil
+	}
+	if r.matches(src) {
+		// Own the pts even on the fast path - trusting src's own pts/timebase
+		// here would break continuity the moment the source switches to one
+		// numbering its frames differently (or not needing conversion, while
+		// a previous source did).
+		src.SetPts(r.pts)
+		src.SetTimeBase(r.timebase)
+		r.pts++
+		return fn(src)
+	}
+
+	if r.ctx == nil || r.srcFmt != src.PixFmt() || r.srcW != src.Width() || r.srcH != src.Height() {
+		if r.ctx != nil {
+			ff.SWScale_free_context(r.ctx)
+			r.ctx = nil
+		}
+		if r.dest == nil {
+			dest, err := frame.NewVideoFrame(src.Stream())
+			if err != nil {
+				return err
+			}
+			dest.SetPixFmt(r.par.PixelFormat())
+			dest.SetWidth(r.par.Width())
+			dest.SetHeight(r.par.Height())
+			if err := dest.AllocateBuffers(); err != nil {
+				dest.Close()
+				return err
+			}
+			r.dest = dest
+		}
+		ctx := ff.SWScale_get_context(
+			src.Width(), src.Height(), src.PixFmt(),
+			r.par.Width(), r.par.Height(), r.par.PixelFormat(),
+			r.flags, nil, nil, nil,
+		)
+		if ctx == nil {
+			return gomedia.ErrInternalError.With("resampler: failed to allocate swscale context")
+		}
+		r.ctx, r.srcFmt, r.srcW, r.srcH = ctx, src.PixFmt(), src.Width(), src.Height()
+	}
+
+	if err := ff.AVUtil_frame_copy_props(r.dest.AVFrame, src.AVFrame); err != nil {
+		return err
+	}
+	if err := ff.SWScale_scale_frame(r.ctx, r.dest.AVFrame, src.AVFrame, false); err != nil {
+		return err
+	}
+
+	// Override whatever pts/timebase frame_copy_props just copied from src -
+	// see the fast path above for why.
+	r.dest.SetPts(r.pts)
+	r.dest.SetTimeBase(r.timebase)
+	r.pts++
+	return fn(r.dest)
+}

--- a/writer/resampler_test.go
+++ b/writer/resampler_test.go
@@ -1,0 +1,576 @@
+package writer
+
+import (
+	"testing"
+
+	// Packages
+	frame "github.com/mutablelogic/go-media/frame"
+	ff "github.com/mutablelogic/go-media/sys/ffmpeg80"
+)
+
+//////////////////////////////////////////////////////////////////////////////
+// HELPERS
+
+func audioCodecParameters(t *testing.T, sampleFmt string, sampleRate int, layout string) *ff.AVCodecParameters {
+	t.Helper()
+	par := ff.AVCodec_parameters_alloc()
+	if par == nil {
+		t.Fatal("AVCodec_parameters_alloc: nil")
+	}
+	t.Cleanup(func() { ff.AVCodec_parameters_free(par) })
+
+	par.SetCodecType(ff.AVMEDIA_TYPE_AUDIO)
+	par.SetSampleFormat(ff.AVUtil_get_sample_fmt(sampleFmt))
+	par.SetSampleRate(sampleRate)
+
+	var ch ff.AVChannelLayout
+	if err := ff.AVUtil_channel_layout_from_string(&ch, layout); err != nil {
+		t.Fatalf("AVUtil_channel_layout_from_string: %v", err)
+	}
+	if err := par.SetChannelLayout(ch); err != nil {
+		t.Fatalf("SetChannelLayout: %v", err)
+	}
+	return par
+}
+
+func videoCodecParameters(t *testing.T, pixFmt string, width, height int) *ff.AVCodecParameters {
+	t.Helper()
+	par := ff.AVCodec_parameters_alloc()
+	if par == nil {
+		t.Fatal("AVCodec_parameters_alloc: nil")
+	}
+	t.Cleanup(func() { ff.AVCodec_parameters_free(par) })
+
+	par.SetCodecType(ff.AVMEDIA_TYPE_VIDEO)
+	par.SetPixelFormat(ff.AVUtil_get_pix_fmt(pixFmt))
+	par.SetWidth(width)
+	par.SetHeight(height)
+	return par
+}
+
+// newS16MonoFrame builds a mono s16 audio frame carrying exactly samples.
+func newS16MonoFrame(t *testing.T, stream, rate int, samples []int16) *frame.AudioFrame {
+	t.Helper()
+	f, err := frame.NewAudioFrame(stream)
+	if err != nil {
+		t.Fatalf("NewAudioFrame: %v", err)
+	}
+	f.SetSampleFormat(ff.AVUtil_get_sample_fmt("s16"))
+	f.SetSampleRate(rate)
+
+	var ch ff.AVChannelLayout
+	if err := ff.AVUtil_channel_layout_from_string(&ch, "mono"); err != nil {
+		t.Fatalf("AVUtil_channel_layout_from_string: %v", err)
+	}
+	if err := f.SetChannelLayout(ch); err != nil {
+		t.Fatalf("SetChannelLayout: %v", err)
+	}
+	f.SetNumSamples(len(samples))
+	if err := f.AllocateBuffers(); err != nil {
+		t.Fatalf("AllocateBuffers: %v", err)
+	}
+	copy(f.Int16(0), samples)
+	return f
+}
+
+func newYUV420PFrame(t *testing.T, stream, width, height int) *frame.VideoFrame {
+	t.Helper()
+	f, err := frame.NewVideoFrame(stream)
+	if err != nil {
+		t.Fatalf("NewVideoFrame: %v", err)
+	}
+	f.SetPixFmt(ff.AVUtil_get_pix_fmt("yuv420p"))
+	f.SetWidth(width)
+	f.SetHeight(height)
+	if err := f.AllocateBuffers(); err != nil {
+		t.Fatalf("AllocateBuffers: %v", err)
+	}
+	return f
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// AUDIO - frameSize accumulation across process() calls (bug #2)
+
+// Feeds a sequence of small input frames (never a multiple of frameSize)
+// carrying a globally increasing sample counter, so any dropped, duplicated
+// or reordered sample is immediately detectable. Regression test for the
+// re-chunking bug: process() used to emit whatever swr produced on every
+// call, rather than buffering short calls until a full chunk was ready.
+func TestAudioResampler_ChunkedAccumulatesAcrossCalls(t *testing.T) {
+	const rate = 8000
+	const frameSize = 100
+	const inputChunk = 30
+	const numInputs = 5 // 150 samples total - 1 full chunk + a 50-sample remainder
+
+	par := audioCodecParameters(t, "s16", rate, "mono")
+	r, err := NewResampler(par, frameSize, ff.AVRational{})
+	if err != nil {
+		t.Fatalf("NewResampler: %v", err)
+	}
+	defer r.audio.Close()
+
+	var next int16
+	var got []int16
+	var gotSizes []int
+
+	emit := func(f frame.Frame) error {
+		af := f.(*frame.AudioFrame)
+		got = append(got, af.Int16(0)...)
+		gotSizes = append(gotSizes, af.NumSamples())
+		return nil
+	}
+
+	for i := 0; i < numInputs; i++ {
+		samples := make([]int16, inputChunk)
+		for j := range samples {
+			samples[j] = next
+			next++
+		}
+		src := newS16MonoFrame(t, 0, rate, samples)
+		err := r.Process(src, emit)
+		src.Close()
+		if err != nil {
+			t.Fatalf("Process(%d): %v", i, err)
+		}
+	}
+	if err := r.Process(nil, emit); err != nil {
+		t.Fatalf("Process(flush): %v", err)
+	}
+
+	const total = numInputs * inputChunk
+	if len(got) != total {
+		t.Fatalf("got %d samples total, want %d", len(got), total)
+	}
+	for i, v := range got {
+		if int(v) != i {
+			t.Fatalf("sample %d = %d, want %d (dropped, duplicated, or reordered sample)", i, v, i)
+		}
+	}
+
+	if len(gotSizes) == 0 {
+		t.Fatal("expected at least one emitted chunk")
+	}
+	for i, n := range gotSizes {
+		if i < len(gotSizes)-1 {
+			if n != frameSize {
+				t.Fatalf("chunk %d has %d samples, want exactly %d", i, n, frameSize)
+			}
+		} else if want := total % frameSize; n != want {
+			t.Fatalf("final chunk has %d samples, want %d", n, want)
+		}
+	}
+}
+
+// Regression test for the pending==0 guard on the matches() fast path: a
+// frame that already matches the target format/rate/layout/frameSize must
+// still go through accumulation (not bypass straight to fn) if a previous
+// short call left samples pending - otherwise it would be emitted out of
+// order, ahead of the older buffered samples.
+func TestAudioResampler_MatchingFrameDoesNotBypassPending(t *testing.T) {
+	const rate = 8000
+	const frameSize = 100
+
+	par := audioCodecParameters(t, "s16", rate, "mono")
+	r, err := NewResampler(par, frameSize, ff.AVRational{})
+	if err != nil {
+		t.Fatalf("NewResampler: %v", err)
+	}
+	defer r.audio.Close()
+
+	var chunks [][]int16
+	emit := func(f frame.Frame) error {
+		af := f.(*frame.AudioFrame)
+		chunk := make([]int16, af.NumSamples())
+		copy(chunk, af.Int16(0))
+		chunks = append(chunks, chunk)
+		return nil
+	}
+
+	// Frame A: 30 samples (0..29) - leaves 30 samples pending, no emit yet.
+	samplesA := make([]int16, 30)
+	for i := range samplesA {
+		samplesA[i] = int16(i)
+	}
+	srcA := newS16MonoFrame(t, 0, rate, samplesA)
+	if err := r.Process(srcA, emit); err != nil {
+		t.Fatalf("Process(A): %v", err)
+	}
+	srcA.Close()
+	if len(chunks) != 0 {
+		t.Fatalf("Process(A): got %d chunks, want 0 (nothing should be emitted yet)", len(chunks))
+	}
+
+	// Frame B: exactly frameSize samples (1000..1099), same format/rate -
+	// matches() would fast-path this straight to fn if not for the
+	// pending-samples guard.
+	samplesB := make([]int16, frameSize)
+	for i := range samplesB {
+		samplesB[i] = int16(1000 + i)
+	}
+	srcB := newS16MonoFrame(t, 0, rate, samplesB)
+	if err := r.Process(srcB, emit); err != nil {
+		t.Fatalf("Process(B): %v", err)
+	}
+	srcB.Close()
+
+	if err := r.Process(nil, emit); err != nil {
+		t.Fatalf("Process(flush): %v", err)
+	}
+
+	if len(chunks) != 2 {
+		t.Fatalf("got %d chunks, want 2", len(chunks))
+	}
+	if len(chunks[0]) != frameSize {
+		t.Fatalf("chunk 0 has %d samples, want %d", len(chunks[0]), frameSize)
+	}
+	for i := 0; i < 30; i++ {
+		if chunks[0][i] != int16(i) {
+			t.Fatalf("chunk 0[%d] = %d, want %d (A's pending samples must come first)", i, chunks[0][i], i)
+		}
+	}
+	for i := 30; i < frameSize; i++ {
+		want := int16(1000 + (i - 30))
+		if chunks[0][i] != want {
+			t.Fatalf("chunk 0[%d] = %d, want %d (B must fill the rest of the chunk in order)", i, chunks[0][i], want)
+		}
+	}
+	if len(chunks[1]) != 30 {
+		t.Fatalf("chunk 1 (flush) has %d samples, want 30", len(chunks[1]))
+	}
+	for i, v := range chunks[1] {
+		want := int16(1000 + 70 + i)
+		if v != want {
+			t.Fatalf("chunk 1[%d] = %d, want %d", i, v, want)
+		}
+	}
+}
+
+// Sanity check for the frameSize<=0 ("codec accepts any frame size") path:
+// output is passed through with no re-chunking, and the total sample count
+// is preserved across a flush.
+func TestAudioResampler_UnboundedPreservesSampleCount(t *testing.T) {
+	const rate = 8000
+	par := audioCodecParameters(t, "s16", rate, "mono")
+	r, err := NewResampler(par, 0, ff.AVRational{})
+	if err != nil {
+		t.Fatalf("NewResampler: %v", err)
+	}
+	defer r.audio.Close()
+
+	var total int
+	emit := func(f frame.Frame) error {
+		total += f.(*frame.AudioFrame).NumSamples()
+		return nil
+	}
+
+	samples := make([]int16, 500)
+	for i := range samples {
+		samples[i] = int16(i)
+	}
+	src := newS16MonoFrame(t, 0, rate, samples)
+	defer src.Close()
+
+	if err := r.Process(src, emit); err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	if err := r.Process(nil, emit); err != nil {
+		t.Fatalf("Process(flush): %v", err)
+	}
+	if total != len(samples) {
+		t.Fatalf("got %d samples total, want %d", total, len(samples))
+	}
+}
+
+// Regression test for owning pts across a source switch: the resampler must
+// never trust a source frame's own pts, since a second source can restart
+// its own numbering (or use a different rate/format) independently of the
+// first - only a resampler-owned, cumulative-sample-count pts stays
+// continuous across the switch. Exercises both the fast (format-matches)
+// path and the full conversion path.
+func TestAudioResampler_OwnsPtsAcrossSourceSwitch(t *testing.T) {
+	const rate = 8000
+	par := audioCodecParameters(t, "s16", rate, "mono")
+	r, err := NewResampler(par, 0, ff.AVRational{})
+	if err != nil {
+		t.Fatalf("NewResampler: %v", err)
+	}
+	defer r.audio.Close()
+
+	var gotPts []int64
+	var gotN []int
+	emit := func(f frame.Frame) error {
+		af := f.(*frame.AudioFrame)
+		gotPts = append(gotPts, af.Pts())
+		gotN = append(gotN, af.NumSamples())
+		return nil
+	}
+
+	// Source A: already matches the target format exactly (fast path) -
+	// carries a large, unrelated pts.
+	srcA := newS16MonoFrame(t, 0, rate, make([]int16, 50))
+	srcA.SetPts(123456)
+	if err := r.Process(srcA, emit); err != nil {
+		t.Fatalf("Process(A): %v", err)
+	}
+	srcA.Close()
+
+	// Source B: switches to double the sample rate (forces real conversion)
+	// and restarts its own pts numbering at an unrelated value.
+	srcB := newS16MonoFrame(t, 0, rate*2, make([]int16, 100))
+	srcB.SetPts(7)
+	if err := r.Process(srcB, emit); err != nil {
+		t.Fatalf("Process(B): %v", err)
+	}
+	srcB.Close()
+
+	if err := r.Process(nil, emit); err != nil {
+		t.Fatalf("Process(flush): %v", err)
+	}
+
+	if len(gotPts) == 0 {
+		t.Fatal("expected at least one emitted frame")
+	}
+	want := int64(0)
+	for i, pts := range gotPts {
+		if pts != want {
+			t.Fatalf("frame %d: pts = %d, want %d (must be cumulative sample count, ignoring src's own pts)", i, pts, want)
+		}
+		want += int64(gotN[i])
+	}
+}
+
+// Regression test for sourceChanged/drain/teardown: switching to a source
+// with a different sample rate or channel layout mid-stream must drain the
+// outgoing context, rebuild ctx for the new source, and keep chunking
+// exactly frameSize samples per frame throughout, with no crash - this
+// exercises the exact cgo channel-layout-comparison path that originally
+// panicked during development ("Go pointer to unpinned Go pointer") when
+// sourceChanged compared a live frame's layout against one stored as a raw
+// AVChannelLayout struct field - and confirms the pending accumulator
+// survives the switch intact rather than being reset or corrupted.
+func TestAudioResampler_SourceChangeDrainsAndReinitializes(t *testing.T) {
+	const frameSize = 100
+	par := audioCodecParameters(t, "s16", 8000, "mono")
+	r, err := NewResampler(par, frameSize, ff.AVRational{})
+	if err != nil {
+		t.Fatalf("NewResampler: %v", err)
+	}
+	defer r.audio.Close()
+
+	var chunkSizes []int
+	emit := func(f frame.Frame) error {
+		chunkSizes = append(chunkSizes, f.(*frame.AudioFrame).NumSamples())
+		return nil
+	}
+
+	// Source A: matches the target format but not frameSize, so it's forced
+	// through real conversion (initializing ctx for the first time) and
+	// leaves a partial chunk pending.
+	srcA := newS16MonoFrame(t, 0, 8000, make([]int16, 30))
+	if err := r.Process(srcA, emit); err != nil {
+		t.Fatalf("Process(A): %v", err)
+	}
+	srcA.Close()
+	if r.audio.pending != 30 {
+		t.Fatalf("pending after A = %d, want 30", r.audio.pending)
+	}
+
+	// Source B: a different sample rate - forces sourceChanged, which
+	// drains and rebuilds ctx. pending must be untouched by the switch.
+	srcB := newS16MonoFrame(t, 0, 16000, make([]int16, 200))
+	if err := r.Process(srcB, emit); err != nil {
+		t.Fatalf("Process(B): %v", err)
+	}
+	srcB.Close()
+
+	// Source C: back to A's rate, but a different channel layout this time -
+	// exercises the layout side of sourceChanged specifically.
+	srcC, err := frame.NewAudioFrame(0)
+	if err != nil {
+		t.Fatalf("NewAudioFrame: %v", err)
+	}
+	srcC.SetSampleFormat(ff.AVUtil_get_sample_fmt("s16"))
+	srcC.SetSampleRate(8000)
+	var stereo ff.AVChannelLayout
+	if err := ff.AVUtil_channel_layout_from_string(&stereo, "stereo"); err != nil {
+		t.Fatalf("AVUtil_channel_layout_from_string: %v", err)
+	}
+	if err := srcC.SetChannelLayout(stereo); err != nil {
+		t.Fatalf("SetChannelLayout: %v", err)
+	}
+	srcC.SetNumSamples(60)
+	if err := srcC.AllocateBuffers(); err != nil {
+		t.Fatalf("AllocateBuffers: %v", err)
+	}
+	if err := r.Process(srcC, emit); err != nil {
+		t.Fatalf("Process(C): %v", err)
+	}
+	srcC.Close()
+
+	if err := r.Process(nil, emit); err != nil {
+		t.Fatalf("Process(flush): %v", err)
+	}
+
+	if len(chunkSizes) == 0 {
+		t.Fatal("expected at least one emitted chunk")
+	}
+	for i, n := range chunkSizes {
+		if i < len(chunkSizes)-1 {
+			if n != frameSize {
+				t.Fatalf("chunk %d has %d samples, want exactly %d", i, n, frameSize)
+			}
+		} else if n <= 0 || n > frameSize {
+			t.Fatalf("final chunk has %d samples, want 1..%d", n, frameSize)
+		}
+	}
+	if r.audio.pending != 0 {
+		t.Fatalf("pending after flush = %d, want 0", r.audio.pending)
+	}
+}
+
+func TestAudioResampler_Close_Idempotent(t *testing.T) {
+	par := audioCodecParameters(t, "s16", 8000, "mono")
+	r, err := NewResampler(par, 100, ff.AVRational{})
+	if err != nil {
+		t.Fatalf("NewResampler: %v", err)
+	}
+
+	src := newS16MonoFrame(t, 0, 8000, make([]int16, 10))
+	if err := r.Process(src, func(frame.Frame) error { return nil }); err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	src.Close()
+
+	if err := r.audio.Close(); err != nil {
+		t.Fatalf("Close (first): %v", err)
+	}
+	if err := r.audio.Close(); err != nil {
+		t.Fatalf("Close (second): %v", err)
+	}
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// VIDEO - context replaced (not dangling) on format/size change (bug #1)
+
+// Regression test for the videoRescaler.process free/realloc path: the old
+// swscale context must never be left set once freed. Repeatedly swapping
+// between sizes exercises that path on every call and confirms the context
+// is always replaced with a fresh one rather than reused after being freed.
+// (Forcing SWScale_get_context itself to fail isn't reproducible through
+// valid public inputs, since NewResampler/newVideoRescaler already reject
+// any parameters that would make allocation fail.)
+func TestVideoRescaler_ContextReplacedOnSizeChange(t *testing.T) {
+	par := videoCodecParameters(t, "yuv420p", 160, 120)
+	r, err := NewResampler(par, 0, ff.AVUtil_rational(1, 25))
+	if err != nil {
+		t.Fatalf("NewResampler: %v", err)
+	}
+	defer r.video.Close()
+
+	// Note: contexts aren't compared by pointer across iterations - the
+	// allocator can legitimately hand back the same address once freed, so
+	// pointer equality wouldn't distinguish "replaced" from "dangling".
+	// What matters is that every swap leaves ctx non-nil and valid to use.
+	sizes := [][2]int{{320, 240}, {640, 480}, {160, 120}, {800, 600}, {320, 240}}
+	for _, dims := range sizes {
+		src := newYUV420PFrame(t, 0, dims[0], dims[1])
+		if err := r.Process(src, func(frame.Frame) error { return nil }); err != nil {
+			src.Close()
+			t.Fatalf("Process(%dx%d): %v", dims[0], dims[1], err)
+		}
+		src.Close()
+
+		if r.video.ctx == nil {
+			t.Fatalf("ctx is nil after successful rescale to %dx%d", dims[0], dims[1])
+		}
+	}
+}
+
+// Regression test for owning pts across a source switch: neither the fast
+// (format-matches) path nor the full rescale path may leak a source frame's
+// own pts/timebase through, since a second source can restart its own
+// numbering (or use a different timebase) independently of the first - only
+// a resampler-owned, one-tick-per-frame pts at the fixed target timebase
+// stays continuous and correctly-scaled across the switch.
+func TestVideoRescaler_OwnsPtsAcrossSourceSwitch(t *testing.T) {
+	const targetW, targetH = 160, 120
+	target := ff.AVUtil_rational(1, 25)
+
+	par := videoCodecParameters(t, "yuv420p", targetW, targetH)
+	r, err := NewResampler(par, 0, target)
+	if err != nil {
+		t.Fatalf("NewResampler: %v", err)
+	}
+	defer r.video.Close()
+
+	var gotPts []int64
+	var gotTb []ff.AVRational
+	emit := func(f frame.Frame) error {
+		vf := f.(*frame.VideoFrame)
+		gotPts = append(gotPts, vf.Pts())
+		gotTb = append(gotTb, vf.TimeBase())
+		return nil
+	}
+
+	// Source A: a different size (forces rescaling), carrying an unrelated
+	// pts/timebase.
+	srcA := newYUV420PFrame(t, 0, 320, 240)
+	srcA.SetPts(999999)
+	srcA.SetTimeBase(ff.AVUtil_rational(1, 90000))
+	if err := r.Process(srcA, emit); err != nil {
+		t.Fatalf("Process(A): %v", err)
+	}
+	srcA.Close()
+
+	// Source B: yet another size, restarting its own pts numbering with a
+	// different timebase again - simulates switching input sources.
+	srcB := newYUV420PFrame(t, 0, 640, 480)
+	srcB.SetPts(0)
+	srcB.SetTimeBase(ff.AVUtil_rational(1, 1000))
+	if err := r.Process(srcB, emit); err != nil {
+		t.Fatalf("Process(B): %v", err)
+	}
+	srcB.Close()
+
+	// Source C: already matches the target format/size exactly (fast path).
+	srcC := newYUV420PFrame(t, 0, targetW, targetH)
+	srcC.SetPts(555)
+	srcC.SetTimeBase(ff.AVUtil_rational(1, 48000))
+	if err := r.Process(srcC, emit); err != nil {
+		t.Fatalf("Process(C): %v", err)
+	}
+	srcC.Close()
+
+	if len(gotPts) != 3 {
+		t.Fatalf("got %d emitted frames, want 3", len(gotPts))
+	}
+	for i, pts := range gotPts {
+		if pts != int64(i) {
+			t.Fatalf("frame %d: pts = %d, want %d (must ignore src's own pts)", i, pts, i)
+		}
+		if gotTb[i] != target {
+			t.Fatalf("frame %d: timebase = %v, want %v (must ignore src's own timebase)", i, gotTb[i], target)
+		}
+	}
+}
+
+func TestVideoRescaler_Close_Idempotent(t *testing.T) {
+	par := videoCodecParameters(t, "yuv420p", 160, 120)
+	r, err := NewResampler(par, 0, ff.AVUtil_rational(1, 25))
+	if err != nil {
+		t.Fatalf("NewResampler: %v", err)
+	}
+
+	src := newYUV420PFrame(t, 0, 320, 240)
+	if err := r.Process(src, func(frame.Frame) error { return nil }); err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	src.Close()
+
+	if err := r.video.Close(); err != nil {
+		t.Fatalf("Close (first): %v", err)
+	}
+	if err := r.video.Close(); err != nil {
+		t.Fatalf("Close (second): %v", err)
+	}
+}

--- a/writer/resampler_test.go
+++ b/writer/resampler_test.go
@@ -88,6 +88,52 @@ func newYUV420PFrame(t *testing.T, stream, width, height int) *frame.VideoFrame 
 	return f
 }
 
+// newS32MonoFrame builds a mono s32 audio frame carrying exactly samples -
+// a different sample format from newS16MonoFrame's, so feeding it where s16
+// is the target forces a real (if simple) format conversion rather than the
+// resampler's fast pass-through path.
+func newS32MonoFrame(t *testing.T, stream, rate int, samples []int32) *frame.AudioFrame {
+	t.Helper()
+	f, err := frame.NewAudioFrame(stream)
+	if err != nil {
+		t.Fatalf("NewAudioFrame: %v", err)
+	}
+	f.SetSampleFormat(ff.AVUtil_get_sample_fmt("s32"))
+	f.SetSampleRate(rate)
+
+	var ch ff.AVChannelLayout
+	if err := ff.AVUtil_channel_layout_from_string(&ch, "mono"); err != nil {
+		t.Fatalf("AVUtil_channel_layout_from_string: %v", err)
+	}
+	if err := f.SetChannelLayout(ch); err != nil {
+		t.Fatalf("SetChannelLayout: %v", err)
+	}
+	f.SetNumSamples(len(samples))
+	if err := f.AllocateBuffers(); err != nil {
+		t.Fatalf("AllocateBuffers: %v", err)
+	}
+	copy(f.Int32(0), samples)
+	return f
+}
+
+// refAVFrame takes a new reference to src's underlying buffer(s) - sharing
+// them (bumped refcount) rather than copying - simulating an encoder that
+// retains a reference to a frame handed to it rather than copying it, per
+// avcodec_send_frame's documented contract.
+func refAVFrame(t *testing.T, src *ff.AVFrame) *ff.AVFrame {
+	t.Helper()
+	ref := ff.AVUtil_frame_alloc()
+	if ref == nil {
+		t.Fatal("AVUtil_frame_alloc: nil")
+	}
+	if err := ff.AVUtil_frame_ref(ref, src); err != nil {
+		ff.AVUtil_frame_free(ref)
+		t.Fatalf("AVUtil_frame_ref: %v", err)
+	}
+	t.Cleanup(func() { ff.AVUtil_frame_free(ref) })
+	return ref
+}
+
 //////////////////////////////////////////////////////////////////////////////
 // AUDIO - frameSize accumulation across process() calls (bug #2)
 
@@ -428,6 +474,131 @@ func TestAudioResampler_SourceChangeDrainsAndReinitializes(t *testing.T) {
 	}
 }
 
+// Regression test for reusing r.dest across calls without protecting it
+// first: avcodec_send_frame is documented to possibly keep a reference to
+// a frame rather than copy it, so overwriting dest's buffer in place on a
+// later call can corrupt a frame the encoder (simulated here via a real
+// AVFrame ref, sharing the same underlying buffer) hasn't released yet.
+// Exercises the frameSize<=0 (unbounded) path specifically.
+func TestAudioResampler_Unbounded_MakeWritableProtectsPreviousFrame(t *testing.T) {
+	const rate = 8000
+	par := audioCodecParameters(t, "s16", rate, "mono")
+	r, err := NewResampler(par, 0, ff.AVRational{})
+	if err != nil {
+		t.Fatalf("NewResampler: %v", err)
+	}
+	defer r.audio.Close()
+
+	var refs []*ff.AVFrame
+	var snapshots [][]int16
+	emit := func(f frame.Frame) error {
+		af := f.(*frame.AudioFrame)
+		ref := refAVFrame(t, af.AVFrame)
+		refs = append(refs, ref)
+		snap := make([]int16, ref.NumSamples())
+		copy(snap, ref.Int16(0))
+		snapshots = append(snapshots, snap)
+		return nil
+	}
+
+	// s32 mono source against an s16 mono target - a real format
+	// conversion (not the fast path), so dest is genuinely written to by
+	// swr on every call. Two calls with clearly different content: if
+	// dest's buffer were overwritten in place, the first call's still-
+	// referenced frame would end up showing the second call's values.
+	samples1 := make([]int32, 50)
+	for i := range samples1 {
+		samples1[i] = 1 << 20
+	}
+	src1 := newS32MonoFrame(t, 0, rate, samples1)
+	if err := r.Process(src1, emit); err != nil {
+		t.Fatalf("Process(1): %v", err)
+	}
+	src1.Close()
+
+	samples2 := make([]int32, 50)
+	for i := range samples2 {
+		samples2[i] = -(1 << 20)
+	}
+	src2 := newS32MonoFrame(t, 0, rate, samples2)
+	if err := r.Process(src2, emit); err != nil {
+		t.Fatalf("Process(2): %v", err)
+	}
+	src2.Close()
+
+	if len(refs) != 2 {
+		t.Fatalf("got %d emitted frames, want 2", len(refs))
+	}
+	for i, ref := range refs {
+		got, want := ref.Int16(0), snapshots[i]
+		for j := range want {
+			if got[j] != want[j] {
+				t.Fatalf("frame %d sample %d = %d, want %d (buffer corrupted by a later call)", i, j, got[j], want[j])
+			}
+		}
+	}
+}
+
+// Same regression as TestAudioResampler_Unbounded_MakeWritableProtectsPreviousFrame,
+// but for the frameSize>0 (chunked) path, which writes into r.dest via
+// accumulate/copyAudioSamples rather than swr directly.
+func TestAudioResampler_Chunked_MakeWritableProtectsPreviousFrame(t *testing.T) {
+	const rate = 8000
+	const frameSize = 50
+	par := audioCodecParameters(t, "s16", rate, "mono")
+	r, err := NewResampler(par, frameSize, ff.AVRational{})
+	if err != nil {
+		t.Fatalf("NewResampler: %v", err)
+	}
+	defer r.audio.Close()
+
+	var refs []*ff.AVFrame
+	var snapshots [][]int16
+	emit := func(f frame.Frame) error {
+		af := f.(*frame.AudioFrame)
+		ref := refAVFrame(t, af.AVFrame)
+		refs = append(refs, ref)
+		snap := make([]int16, ref.NumSamples())
+		copy(snap, ref.Int16(0))
+		snapshots = append(snapshots, snap)
+		return nil
+	}
+
+	// Exactly frameSize samples each call, so each call completes and
+	// emits exactly one chunk - two calls with clearly different content.
+	samples1 := make([]int32, frameSize)
+	for i := range samples1 {
+		samples1[i] = 1 << 20
+	}
+	src1 := newS32MonoFrame(t, 0, rate, samples1)
+	if err := r.Process(src1, emit); err != nil {
+		t.Fatalf("Process(1): %v", err)
+	}
+	src1.Close()
+
+	samples2 := make([]int32, frameSize)
+	for i := range samples2 {
+		samples2[i] = -(1 << 20)
+	}
+	src2 := newS32MonoFrame(t, 0, rate, samples2)
+	if err := r.Process(src2, emit); err != nil {
+		t.Fatalf("Process(2): %v", err)
+	}
+	src2.Close()
+
+	if len(refs) != 2 {
+		t.Fatalf("got %d emitted frames, want 2", len(refs))
+	}
+	for i, ref := range refs {
+		got, want := ref.Int16(0), snapshots[i]
+		for j := range want {
+			if got[j] != want[j] {
+				t.Fatalf("frame %d sample %d = %d, want %d (buffer corrupted by a later call)", i, j, got[j], want[j])
+			}
+		}
+	}
+}
+
 func TestAudioResampler_Close_Idempotent(t *testing.T) {
 	par := audioCodecParameters(t, "s16", 8000, "mono")
 	r, err := NewResampler(par, 100, ff.AVRational{})
@@ -550,6 +721,64 @@ func TestVideoRescaler_OwnsPtsAcrossSourceSwitch(t *testing.T) {
 		}
 		if gotTb[i] != target {
 			t.Fatalf("frame %d: timebase = %v, want %v (must ignore src's own timebase)", i, gotTb[i], target)
+		}
+	}
+}
+
+// Same regression as the audio MakeWritable tests, for the video rescale
+// path, which writes into r.dest via SWScale_scale_frame.
+func TestVideoRescaler_MakeWritableProtectsPreviousFrame(t *testing.T) {
+	par := videoCodecParameters(t, "yuv420p", 160, 120)
+	r, err := NewResampler(par, 0, ff.AVUtil_rational(1, 25))
+	if err != nil {
+		t.Fatalf("NewResampler: %v", err)
+	}
+	defer r.video.Close()
+
+	var refs []*ff.AVFrame
+	var snapshots [][]byte
+	emit := func(f frame.Frame) error {
+		vf := f.(*frame.VideoFrame)
+		ref := refAVFrame(t, vf.AVFrame)
+		refs = append(refs, ref)
+		snap := make([]byte, len(ref.Bytes(0)))
+		copy(snap, ref.Bytes(0))
+		snapshots = append(snapshots, snap)
+		return nil
+	}
+
+	// A different size from the 160x120 target forces a real rescale (not
+	// the fast path), so dest is genuinely written to every call. Two
+	// calls with clearly different luma fill values: if dest's buffer were
+	// overwritten in place, the first call's still-referenced frame would
+	// end up showing the second call's values.
+	src1 := newYUV420PFrame(t, 0, 320, 240)
+	for i := range src1.Bytes(0) {
+		src1.Bytes(0)[i] = 10
+	}
+	if err := r.Process(src1, emit); err != nil {
+		t.Fatalf("Process(1): %v", err)
+	}
+	src1.Close()
+
+	src2 := newYUV420PFrame(t, 0, 320, 240)
+	for i := range src2.Bytes(0) {
+		src2.Bytes(0)[i] = 200
+	}
+	if err := r.Process(src2, emit); err != nil {
+		t.Fatalf("Process(2): %v", err)
+	}
+	src2.Close()
+
+	if len(refs) != 2 {
+		t.Fatalf("got %d emitted frames, want 2", len(refs))
+	}
+	for i, ref := range refs {
+		got, want := ref.Bytes(0), snapshots[i]
+		for j := range want {
+			if got[j] != want[j] {
+				t.Fatalf("frame %d byte %d = %d, want %d (buffer corrupted by a later call)", i, j, got[j], want[j])
+			}
 		}
 	}
 }

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -23,6 +23,7 @@ import (
 
 	// Packages
 	gomedia "github.com/mutablelogic/go-media"
+	frame "github.com/mutablelogic/go-media/frame"
 	profile "github.com/mutablelogic/go-media/profile/schema"
 	ff "github.com/mutablelogic/go-media/sys/ffmpeg80"
 	types "github.com/mutablelogic/go-server/pkg/types"
@@ -32,17 +33,20 @@ import (
 // TYPES
 
 // Writer is a wrapper around an AVFormatContext that provides a higher-level
-// interface for writing media files. It embeds an Encoder, giving it Add,
-// Encode, Flush and FrameSize for free — one codec context per stream,
-// opened alongside each stream's AVStream in open().
+// interface for writing media files. It embeds an Encoder, giving it Add and
+// FrameSize for free — one codec context per stream, opened alongside each
+// stream's AVStream in open(). Encode and Flush are overridden (see below) to
+// resample/rescale a frame into the exact format its stream's codec expects
+// before handing it to the embedded Encoder.
 type Writer struct {
 	sync.Mutex
 	opts
 	*Encoder
-	output  *ff.AVFormatContext
-	header  bool           // Track if header was successfully written (for Close)
-	artwork map[int][]byte // Map of stream index to artwork data
-	once    sync.Once
+	output     *ff.AVFormatContext
+	header     bool               // Track if header was successfully written (for Close)
+	artwork    map[int][]byte     // Map of stream index to artwork data
+	resamplers map[int]*Resampler // Map of stream index to its resampler, if any (audio/video only)
+	once       sync.Once
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -132,6 +136,25 @@ func NewWriter(w io.Writer, output *profile.Output, opts ...Opt) (*Writer, error
 func (w *Writer) Close() error {
 	var result error
 
+	// Flush every stream first, so any samples not yet forming a full chunk
+	// (via its resampler) and any packets still buffered inside its codec
+	// (e.g. B-frame reordering delay) are written before the trailer, even
+	// if the caller never called Flush itself. A stream the caller already
+	// flushed returns io.EOF here - that just means there was nothing left,
+	// not a real error.
+	//
+	// This must happen before the lock below is taken: Flush's packets flow
+	// through the embedded Encoder's callback (writePacket), which takes
+	// the same lock itself on every call - holding it here too would
+	// deadlock.
+	if w.header && w.output != nil {
+		for stream := range w.streams {
+			if err := w.Flush(stream); err != nil && !errors.Is(err, io.EOF) {
+				result = errors.Join(result, err)
+			}
+		}
+	}
+
 	// Mutex lock to ensure thread safety
 	w.Lock()
 	defer w.Unlock()
@@ -153,6 +176,13 @@ func (w *Writer) Close() error {
 		result = errors.Join(result, w.Encoder.Close())
 	}
 
+	// Close every stream's resampler, freeing the swr/sws contexts they own -
+	// already flushed above, so nothing left to drain here.
+	for _, r := range w.resamplers {
+		result = errors.Join(result, r.Close())
+	}
+	w.resamplers = nil
+
 	// Free output resources
 	if w.output != nil {
 		result = errors.Join(result, ff.AVFormat_close_writer(w.output))
@@ -168,13 +198,46 @@ func (w *Writer) Close() error {
 }
 
 //////////////////////////////////////////////////////////////////////////////
+// PUBLIC METHODS
+
+// Encode converts f via its stream's resampler (built in open(), if the
+// stream is audio/video) into the exact format its codec was opened with,
+// then hands the result to the embedded Encoder. Frames for a stream with no
+// registered resampler (subtitles) pass straight through.
+func (w *Writer) Encode(f frame.Frame) error {
+	if f == nil {
+		return gomedia.ErrBadParameter.With("nil frame")
+	}
+	r, ok := w.resamplers[f.Stream()]
+	if !ok {
+		return w.Encoder.Encode(f)
+	}
+	return r.Process(f, w.Encoder.Encode)
+}
+
+// Flush drains stream's resampler (if any) of any samples not yet forming a
+// full frame, then flushes the encoder. Resampler.Process(nil, ...) is
+// documented as a no-op for video/passthrough, so this only does real work
+// for audio. Safe to call more than once for the same stream - the encoder
+// returns io.EOF for a stream already flushed, rather than an error.
+func (w *Writer) Flush(stream int) error {
+	if r, ok := w.resamplers[stream]; ok {
+		if err := r.Process(nil, w.Encoder.Encode); err != nil {
+			return err
+		}
+	}
+	return w.Encoder.Flush(stream)
+}
+
+//////////////////////////////////////////////////////////////////////////////
 // PRIVATE METHODS
 
 func (writer *Writer) open(output *profile.Output) (*Writer, error) {
 	var result error
 
-	// Initialize the artwork map
+	// Initialize the artwork and resampler maps
 	writer.artwork = make(map[int][]byte)
+	writer.resamplers = make(map[int]*Resampler)
 
 	// Create streams in a deterministic order (map iteration order is
 	// randomized, but stream creation order determines each stream's
@@ -215,6 +278,30 @@ func (writer *Writer) open(output *profile.Output) (*Writer, error) {
 		if err := writer.Encoder.Add(id, profile, codecFlags...); err != nil {
 			result = errors.Join(result, err)
 			continue
+		}
+
+		// Build a resampler for audio/video streams, so Writer.Encode can
+		// convert an incoming frame into the exact format this stream's
+		// codec was opened with, rather than requiring the caller to do it.
+		// profile.Par() (Go-managed) is used here rather than the codec
+		// parameters just opened above (C-allocated, freed further down) -
+		// the resampler holds onto this pointer for its entire lifetime, so
+		// it must not be one that gets freed out from under it.
+		switch ff.AVMediaType(profile.Type()) {
+		case ff.AVMEDIA_TYPE_AUDIO:
+			r, err := newAudioResampler(profile.Par(), writer.Encoder.FrameSize(id))
+			if err != nil {
+				result = errors.Join(result, err)
+				continue
+			}
+			writer.resamplers[id] = r
+		case ff.AVMEDIA_TYPE_VIDEO:
+			r, err := newVideoRescaler(profile.Par(), types.Value(profile.TimeBase()))
+			if err != nil {
+				result = errors.Join(result, err)
+				continue
+			}
+			writer.resamplers[id] = r
 		}
 
 		// Copy codec parameters from the now-opened codec context

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -331,6 +331,45 @@ func TestWriter_EncodeFrame(t *testing.T) {
 	}
 }
 
+// Every other Encode test feeds silentFrame, which already matches
+// audioStream's aac profile (fltp stereo @ 44.1kHz) exactly - so they only
+// ever exercise the resampler's fast pass-through path. This one feeds a
+// deliberately mismatched format (s16 mono @ 8kHz, in irregular chunk
+// sizes) to prove Writer.Encode actually resamples via the stream's
+// resampler, end to end, rather than just wiring it in unused.
+func TestWriter_EncodeFrame_Resampled(t *testing.T) {
+	output := profile.OutputWithName("mp4")
+	if output == nil {
+		t.Fatal("OutputWithName(mp4): nil output")
+	}
+
+	var buf bytes.Buffer
+	w, err := writer.NewWriter(&buf, output, writer.WithProfile(0, audioStream(t)))
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+
+	for i := 0; i < 10; i++ {
+		f := mismatchedFrame(t, 0, 512)
+		if err := w.Encode(f); err != nil {
+			f.Close()
+			t.Fatalf("Encode: %v", err)
+		}
+		f.Close()
+	}
+
+	if err := w.Flush(0); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if buf.Len() == 0 {
+		t.Fatal("expected non-empty output buffer")
+	}
+}
+
 func TestClose_Idempotent(t *testing.T) {
 	output := profile.OutputWithName("mp4")
 	if output == nil {
@@ -347,5 +386,44 @@ func TestClose_Idempotent(t *testing.T) {
 	}
 	if err := w.Close(); err != nil {
 		t.Fatalf("Close (second): %v", err)
+	}
+}
+
+// Regression test for Close's safety-net flush: every other Encode test
+// calls Flush(0) explicitly before Close, so none of them actually exercise
+// Close's own flush loop. This one relies on Close alone to drain the
+// resampler's pending partial chunk and the codec's own buffered packets -
+// this exact path previously deadlocked (Close held its lock across a
+// Flush call whose packets loop back through the same lock via
+// writePacket), so this also guards against that regressing.
+func TestWriter_Close_FlushesWithoutExplicitFlush(t *testing.T) {
+	output := profile.OutputWithName("mp4")
+	if output == nil {
+		t.Fatal("OutputWithName(mp4): nil output")
+	}
+
+	var buf bytes.Buffer
+	w, err := writer.NewWriter(&buf, output, writer.WithProfile(0, audioStream(t)))
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+
+	// Mismatched, irregular-sized chunks - guarantees the resampler has a
+	// partial chunk still pending when Close is called.
+	for i := 0; i < 10; i++ {
+		f := mismatchedFrame(t, 0, 512)
+		if err := w.Encode(f); err != nil {
+			f.Close()
+			t.Fatalf("Encode: %v", err)
+		}
+		f.Close()
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if buf.Len() == 0 {
+		t.Fatal("expected non-empty output buffer")
 	}
 }


### PR DESCRIPTION
This pull request introduces a significant enhancement to the `writer.Writer` implementation by integrating per-stream resampling and rescaling, ensuring all audio/video frames are converted into the exact format required by their codecs. This eliminates the need for callers to pre-convert frames, making the API easier and safer to use. The changes also improve resource management and robustness, especially around stream flushing and closing. Comprehensive tests are added to verify the new behavior and guard against regressions.

### Writer API and Resampler Integration

* Added a `resamplers` map to `writer.Writer`, associating each stream with its own audio/video resampler or video rescaler, automatically converting frames to the required codec format during `Encode`. (`writer/writer.go` [[1]](diffhunk://#diff-26d4fcf1ea0693620c557d21296e08c0517e901e2b01c8d4d93ac5ac5ffd4582L35-R48) [[2]](diffhunk://#diff-26d4fcf1ea0693620c557d21296e08c0517e901e2b01c8d4d93ac5ac5ffd4582R283-R306)
* Overrode `Encode` and `Flush` in `writer.Writer` to route frames through the appropriate resampler before encoding, and to ensure all buffered data is flushed from both the resampler and encoder. (`writer/writer.go` [writer/writer.goR200-R240](diffhunk://#diff-26d4fcf1ea0693620c557d21296e08c0517e901e2b01c8d4d93ac5ac5ffd4582R200-R240))
* Modified `Writer.Close` to flush all streams (draining both resamplers and encoders) before closing, and to free all resampler resources, preventing deadlocks and resource leaks. (`writer/writer.go` [[1]](diffhunk://#diff-26d4fcf1ea0693620c557d21296e08c0517e901e2b01c8d4d93ac5ac5ffd4582R139-R157) [[2]](diffhunk://#diff-26d4fcf1ea0693620c557d21296e08c0517e901e2b01c8d4d93ac5ac5ffd4582R179-R185)

### Testing and Validation

* Added `mismatchedFrame` helper and new tests to verify that `Writer.Encode` properly resamples frames that do not match the stream's codec format, and that `Writer.Close` safely flushes all pending data even if `Flush` was not explicitly called by the user. (`writer/encoder_test.go` [[1]](diffhunk://#diff-d6fcf81a50634ac7c1995763ee76e72e5a0ecea7741375b12a3cda69311d8f91R54-R89) `writer/writer_test.go` [[2]](diffhunk://#diff-32069081bdb783b58f32804fc83320b607063f230f60d1a9686a00c7814fb625R334-R372) [[3]](diffhunk://#diff-32069081bdb783b58f32804fc83320b607063f230f60d1a9686a00c7814fb625R391-R429)

### Documentation and Code Quality

* Updated and clarified comments throughout, including function headers and struct documentation, to accurately reflect the new resampler behavior and resource management. (`writer/writer.go` [[1]](diffhunk://#diff-26d4fcf1ea0693620c557d21296e08c0517e901e2b01c8d4d93ac5ac5ffd4582L35-R48) [[2]](diffhunk://#diff-26d4fcf1ea0693620c557d21296e08c0517e901e2b01c8d4d93ac5ac5ffd4582R283-R306)
* Fixed minor docstring inaccuracies in unrelated files (`task/manager/manager.go`, `task/manager/opt.go`) for improved clarity. [[1]](diffhunk://#diff-3ce25fa164718e41cabab20d002b34646325bcdd8623320e5cfb1c8cfaede47dL40-R40) [[2]](diffhunk://#diff-1333d067eed201d9fc1bee84dd2a786b63a84e9d314070ffa2e03519f21f297dL11-R11) [[3]](diffhunk://#diff-3ce25fa164718e41cabab20d002b34646325bcdd8623320e5cfb1c8cfaede47dL305-R308)