### PR TITLE
Update Node.js version to 24 and improve retry logic

### DIFF
--- a/.github/workflows/on_publish.yaml
+++ b/.github/workflows/on_publish.yaml
@@ -36,7 +36,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Login
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -58,7 +58,7 @@ jobs:
       packages: write
     steps:
       - name: Login
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CURL=$(shell which curl)
 NPM ?= $(shell which npm 2>/dev/null)
 
 # Curl retry policy for flaky downloads
-CURL_RETRY_FLAGS = --fail --location --retry 3 --retry-delay 5 --retry-all-errors
+CURL_RETRY_FLAGS = --fail --location --retry 5 --retry-delay 10 --retry-all-errors
 
 # Default parallelism
 JOBS ?= $(shell nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 1)
@@ -84,8 +84,8 @@ $(CMD_DIR): go-dep go-tidy sdl-dep chromaprint-dep mkdir
 ${BUILD_DIR}/${FFMPEG_VERSION}:
 	@if [ ! -d "$(BUILD_DIR)/$(FFMPEG_VERSION)" ]; then \
 		echo "Downloading $(FFMPEG_VERSION)"; \
-		$(CURL) $(CURL_RETRY_FLAGS) -o "$(BUILD_DIR)/ffmpeg.tar.gz" https://ffmpeg.org/releases/$(FFMPEG_VERSION).tar.gz; \
-		tar -xzf "$(BUILD_DIR)/ffmpeg.tar.gz" -C "$(BUILD_DIR)"; \
+		$(CURL) $(CURL_RETRY_FLAGS) -o "$(BUILD_DIR)/ffmpeg.tar.gz" https://ffmpeg.org/releases/$(FFMPEG_VERSION).tar.gz && \
+		tar -xzf "$(BUILD_DIR)/ffmpeg.tar.gz" -C "$(BUILD_DIR)" && \
 		rm -f "$(BUILD_DIR)/ffmpeg.tar.gz"; \
 	fi
 


### PR DESCRIPTION
This pull request updates the Docker login GitHub Actions to use the latest version and improves the reliability of downloads in the `Makefile` by adjusting retry policies and error handling.

**CI/CD Workflow Updates:**
* Updated the Docker login action from `v3` to `v4` in `.github/workflows/on_publish.yaml` to use the latest features and security improvements. [[1]](diffhunk://#diff-3828dfff5cf0d68a8a95b68eafe6166d3e933959820ac7ce7654debf0369e956L39-R39) [[2]](diffhunk://#diff-3828dfff5cf0d68a8a95b68eafe6166d3e933959820ac7ce7654debf0369e956L61-R61)

**Build Reliability Improvements:**
* Increased the number of retries and delay for curl downloads in the `Makefile` to better handle flaky network issues.
* Improved error handling in the FFmpeg download step by chaining commands with `&&` to ensure the tar extraction and cleanup only run if the download succeeds.